### PR TITLE
Hclang 70 classname as error text

### DIFF
--- a/code/src/main/kotlin/exceptions/CompilationException.kt
+++ b/code/src/main/kotlin/exceptions/CompilationException.kt
@@ -9,7 +9,7 @@ package exceptions
 abstract class CompilationException(val lineNumber: Int,
                                     val lineIndex: Int,
                                     val lineText: String): Exception(){
-    abstract val errorType: String
+    val errorType = this::class.simpleName
     abstract val errorMessage: String
     abstract val helpText: String
 }

--- a/code/src/main/kotlin/exceptions/MissingArgumentError.kt
+++ b/code/src/main/kotlin/exceptions/MissingArgumentError.kt
@@ -6,7 +6,6 @@ package exceptions
  */
 class MissingArgumentError(lineNumber: Int, lineIndex: Int, lineText: String, private val functionName: String)
     : ParserException(lineNumber, lineIndex, lineText){
-    override val errorType = "MISSING-ARGUMENT-ERROR"
     override val errorMessage  = "Missing argument for function '$functionName'."
     override val helpText = "Have you included all arguments for function?"
 }

--- a/code/src/main/kotlin/exceptions/MissingEncapsulationError.kt
+++ b/code/src/main/kotlin/exceptions/MissingEncapsulationError.kt
@@ -6,7 +6,6 @@ package exceptions
 class MissingEncapsulationError(lineNumber: Int, lineIndex: Int, lineText: String)
     : ParserException(lineNumber, lineIndex, lineText){
     private val missingToken: Char = lineText[lineIndex]
-    override val errorType = "MISSING-ENCAPSULATION-ERROR"
     override val errorMessage = "Missing closing character for '$missingToken'"
     override val helpText  = "Remember to always close encapsulations."
 }

--- a/code/src/main/kotlin/exceptions/StringDoesntEndError.kt
+++ b/code/src/main/kotlin/exceptions/StringDoesntEndError.kt
@@ -6,7 +6,6 @@ package exceptions
 class StringDoesntEndError(lineNumber: Int, lineIndex: Int, lineText: String)
     : ParserException(lineNumber, lineIndex, lineText){
     private val missingToken: String = lineText.substring(lineIndex)
-    override val errorType = "STRING-DOESNT-END-ERROR"
     override val errorMessage = "TXT literal lacks closing - '$missingToken'"
     override val helpText  = "Try adding a ' or \" "
 }

--- a/code/src/main/kotlin/exceptions/TypeError.kt
+++ b/code/src/main/kotlin/exceptions/TypeError.kt
@@ -10,7 +10,6 @@ class TypeError(lineNumber: Int, lineIndex: Int, lineText: String,
                 : ParserException(lineNumber, lineIndex, lineText) {
     private val types: String = findTypes()
 
-    override val errorType = "TYPE-ERROR"
     override val errorMessage = "Function '$operator' not defined for types: $types."
     override val helpText = "Try casting your types to match eachother."
 

--- a/code/src/main/kotlin/exceptions/UndeclaredError.kt
+++ b/code/src/main/kotlin/exceptions/UndeclaredError.kt
@@ -6,7 +6,6 @@ package exceptions
  */
 class UndeclaredError(lineNumber: Int, lineIndex: Int, lineText: String, private val nameOfVar: String)
     : ParserException(lineNumber, lineIndex, lineText){
-    override val errorType = "UNDECLARED-ERROR"
     override val errorMessage = "Undeclared identifier '$nameOfVar' found."
     override val helpText = "Declare identifier before use."
 }

--- a/code/src/main/kotlin/exceptions/UninitializedError.kt
+++ b/code/src/main/kotlin/exceptions/UninitializedError.kt
@@ -6,7 +6,6 @@ package exceptions
  */
 class UninitializedError(lineNumber: Int, lineIndex: Int, lineText: String, private val nameOfVar: String)
                         : ParserException(lineNumber, lineIndex, lineText){
-    override val errorType = "UNINITIALIZED-ERROR"
     override val errorMessage = "Use of uninitialized variable '$nameOfVar' found."
     override val helpText = "Try initializing variable before use."
 }

--- a/code/src/main/kotlin/exceptions/ZeroDivisionError.kt
+++ b/code/src/main/kotlin/exceptions/ZeroDivisionError.kt
@@ -5,7 +5,6 @@ package exceptions
  */
 class ZeroDivisionError(lineNumber: Int, lineIndex: Int, lineText: String)
     : ParserException(lineNumber, lineIndex, lineText){
-    override val errorType = "ZERO-DIVISION-ERROR"
     override val errorMessage = "Division by 0 found"
     override val helpText = "Check your variables"
 }

--- a/code/src/main/kotlin/lexer/Tokens.kt
+++ b/code/src/main/kotlin/lexer/Tokens.kt
@@ -8,7 +8,7 @@ sealed class Token {
         override fun toString() = super.toString() + "[$value]"
     }
 
-    override fun toString() = this.javaClass.name!!
+    override fun toString() = this::class.simpleName!!
 
     sealed class Literal : Token() {
         class Text(val value: String) : Literal() {

--- a/code/src/test/kotlin/loggerTests/LoggerTest.kt
+++ b/code/src/test/kotlin/loggerTests/LoggerTest.kt
@@ -11,7 +11,7 @@ class TokenTest {
         val logger = TestLogger()
         logger.logCompilationError(error)
         assertEquals(
-                "- ERROR: TYPE-ERROR found at line 4 index 10:\n" +
+                "- ERROR: TypeError found at line 4 index 10:\n" +
                         " | var b = 4 < \"5\"\n" +
                         " |           ^--\n" +
                         " | Function '<' not defined for types: 'num', 'txt' and 'bool'.\n" +
@@ -24,7 +24,7 @@ class TokenTest {
         val logger = TestLogger()
         logger.logCompilationError(error)
         assertEquals(
-                "- ERROR: UNDECLARED-ERROR found at line 12 index 8:\n" +
+                "- ERROR: UndeclaredError found at line 12 index 8:\n" +
                         " | txt s = textString\n" +
                         " |         ^--\n" +
                         " | Undeclared identifier 'textString' found.\n" +
@@ -37,7 +37,7 @@ class TokenTest {
         val logger = TestLogger()
         logger.logCompilationError(error)
         assertEquals(
-                "- ERROR: UNINITIALIZED-ERROR found at line 12 index 4:\n" +
+                "- ERROR: UninitializedError found at line 12 index 4:\n" +
                         " | x = someUninitializedVariable + 10\n" +
                         " |     ^--\n" +
                         " | Use of uninitialized variable 'someUninitializedVariable' found.\n" +
@@ -50,7 +50,7 @@ class TokenTest {
         val logger = TestLogger()
         logger.logCompilationError(error)
         assertEquals(
-                "- ERROR: ZERO-DIVISION-ERROR found at line 7 index 6:\n" +
+                "- ERROR: ZeroDivisionError found at line 7 index 6:\n" +
                         " | x = 42/0\n" +
                         " |       ^--\n" +
                         " | Division by 0 found\n" +
@@ -62,7 +62,7 @@ class TokenTest {
         val logger = TestLogger()
         logger.logCompilationError(error)
         assertEquals(
-                "- ERROR: MISSING-ARGUMENT-ERROR found at line 11 index 2:\n" +
+                "- ERROR: MissingArgumentError found at line 11 index 2:\n" +
                         " | 2 someFunction\n" +
                         " |   ^--\n" +
                         " | Missing argument for function 'someFunction'.\n" +
@@ -74,7 +74,7 @@ class TokenTest {
         val logger = TestLogger()
         logger.logCompilationError(error)
         assertEquals(
-                "- ERROR: MISSING-ENCAPSULATION-ERROR found at line 30 index 0:\n" +
+                "- ERROR: MissingEncapsulationError found at line 30 index 0:\n" +
                         " | ({()}\n" +
                         " | ^--\n" +
                         " | Missing closing character for '('\n" +


### PR DESCRIPTION
### Description
Changed errors errortype to correspond to their class name.

### Changelog
 - Errors now show their class name as errortype.
 - Also used kotlin simple name for lexer tokens.

### Issues solved 
add these with the respective key as HCLANG-1 (as an example)
 - HCLANG-70

## FOR REVIEWER [Do not remove]
A small checklist of things to note when you are doing a review. Make sure these things apply before going into master.
 - Did the PR actually fix the issue
 - Comment anything that doesn't make sense or anything you want clarified. Many comments are always ok
 - Make sure this is ready for exams if this is going into master
 - It's always a good idea having another reviewer look at a PR as well, if it's major. get a buddy.

### Regarding filenames
- all .tex files use pascal case
- all other files [except in /code/] use snake case


### Regarding code [if applicable]
- Check [coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html)
- Are public methods documented? 
- Are there testcases for new features / methods?
- Have you tried running the source and tested things that cannot be test-cased?

### Regarding Report [if applicable]
- Does each line have a linechange in the sourcecode?
- Does sentences make sense?
- Did you do spellchecking?
- Citations?
