### PR TITLE
Hclang 79 kotlin hcl listing

### DIFF
--- a/report/3.Theory/LanguageSpecification.tex
+++ b/report/3.Theory/LanguageSpecification.tex
@@ -35,7 +35,7 @@ Therefore, types can be declared using the keyword \textbf{\textit{var}} (short 
 Declarations can also be explicit by prefixing the type of the variable before an assignment(line 2), or by prefixing the type before the variable without an assignment(line 3).
 The three methods of declaration are seen in snippet below.
 A  \textbf{\textit{num}} example is also shown.
-\begin{lstlisting}
+\begin{lstlisting}[language=HCL,label=lis:hclTypeDcls,firstnumber=1]
 var x = 5
 num y = 10
 txt s = "string"
@@ -60,13 +60,13 @@ The declaration is structured as an assignment, where the functions name is decl
 The parameters of the function is declared on the right-hand-side inside parentheses, followed by a colon (\textbf{\textit{:}}), which declares the return type. 
 
 An example function that adds two numbers together and returns the value is shown below:
-\begin{lstlisting}
+\begin{lstlisting}[language=HCL,label=lis:addNumbers,firstnumber=1]
 var addNumbers = (num a, num b): num {
     a + b
 }
 \end{lstlisting} 
 A more explicit declaration of the same function can be seen in the snippet below:
-\begin{lstlisting}
+\begin{lstlisting}[language=HCL,label=lis:hclExplicitTypeDcls,firstnumber=1]
 func[num,num,none] addNumbers = (num a, num b): num {
 	return a + b
 }
@@ -93,7 +93,7 @@ Lambdas can be used as parameters by encapsulation with curly-brackets.
 
 Below is an example of function calls where the program prints a name from a list:
 The \textbf{where} function in this example returns an entry in the list based on a lambda expression.
-\begin{lstlisting}
+\begin{lstlisting}[language=HCL,label=lis:hclPrintnFromList,firstnumber=1]
 ["john", "frank"] where {value is "frank"} print
 \end{lstlisting}
 
@@ -126,7 +126,7 @@ Loops are created using either of the predefined functions \textbf{\textit{forea
 When creating ranges the predefined \textbf{\textit{to}} function, that returns a list, can be used. 
 
 Following is a small example that prints numbers using the \textbf{\textit{do}} function:
-\begin{lstlisting}
+\begin{lstlisting}[language=HCL,label=lis:hclTypeDcls,firstnumber=1]
 1 to 10 do {value print}
 \end{lstlisting}
 There are no equivalent functions to the \textbf{\textit{while}} loop structure in HCL, as all looping will be done using iterations.
@@ -140,7 +140,7 @@ However, when using a predeclared function, the identifier should be prefixed wi
 Since lambdas should not be prefixed with a colon, it makes it impossible for a lambda to be invoked in-line. 
 Therefore lambdas may only be passed as parameters, and never invoked by themselves.
 Below is an example of how high-order functionality is used in HCL.
-\begin{lstlisting}
+\begin{lstlisting}[language=HCL,label=lis:hclTypeDcls,firstnumber=1]
 var modifyNumber = (num n, func[num, num] modifyFunction): num { n modifyFunction }
 
 # Used with lamdas
@@ -173,8 +173,8 @@ Should it be necessary to overload functions with varying lengths of input-param
 Function overloading requires nothing special of the user, simply declare two functions with the same amount of parameters, but with different types. 
 See listings below for example
 
-\begin{lstlisting}
-var isAwesome = (string name): bool {
+\begin{lstlisting}[language=HCL,label=lis:hclTypeDcls,firstnumber=1]
+var isAwesome = (txt name): bool {
 	name equals "HCL" thenElse {true} {false}
 }
 var isAwesome = (num number): bool {
@@ -202,7 +202,7 @@ However, this would require overloading of a lot of functions with all the possi
 Since tuples are distinguished by the types within it, there are a theoretical infinite amount of types within HCL, which in turn makes overloading for this case impossible.
 
 To get a better grasp of how generics are used in HCL, consider the following implementation of the map function:
-\begin{lstlisting}
+\begin{lstlisting}[language=HCL,label=lis:hclTypeDcls,firstnumber=1]
 var map = (list[T1] elementsToMap, func[T1, T2] mapFunction): list[T2] {
 	list[T2] mappedValues = []
 	elementsToMap onEach {mappedValues add (value mapFunction)}

--- a/report/4.Solution/LexerImplementation.tex
+++ b/report/4.Solution/LexerImplementation.tex
@@ -10,7 +10,7 @@ The \textit{Token} class simply specifies the type of a token.
 It is implemented as a Sealed class. 
 A sealed class in Kotlin, simply specifies that a value can have one specific type, from a predefined set\cite{KotlinSealed}.
 It is essentially an extended enum.
-\begin{lstlisting}[language=java,label=lis:tokenClass,caption=A snippet from the token class .,firstnumber=9]
+\begin{lstlisting}[language=Kotlin,label=lis:tokenClass,caption=A snippet from the token class .,firstnumber=9]
 sealed class Literal : Token() {
 	class Text(val value: String) : Literal() {
 	override fun toString() = super.toString() + "[$value]"
@@ -26,20 +26,20 @@ sealed class Literal : Token() {
 
 The \textit{PositionalToken} class is a wrapper class for a token, and simply contains additional information regarding linenumber and line index.
 The positional token is mainly implemented to help with error reporting.
-\begin{lstlisting}[language=java,label=lis:PositionalTokenClass,caption=A snippet from the token class .,firstnumber=10]
+\begin{lstlisting}[language=Kotlin,label=lis:PositionalTokenClass,caption=A snippet from the token class .,firstnumber=10]
 class PositionalToken(val token: Token, val lineNumber: Int, val lineIndex: Int)
 \end{lstlisting}
 
 The bulk of the logic regarding the lexer is done in the \textit{Lexer} class.
 The \textit{Lexer} class implements the \textit{ILexer} interface.
 
-\begin{lstlisting}[language=java,label=lis:Lexer,caption=The Lexer .,firstnumber=8]
+\begin{lstlisting}[language=Kotlin,label=lis:Lexer,caption=The Lexer .,firstnumber=8]
 class Lexer(private val inputContent: String) : ILexer {
 \end{lstlisting}
 
 The \textit{ILexer} defines a \textit{getTokenSequence} function, which will give the token sequence, and an \textit{inputLine} function.
 The \textit{getTokenSequence} function will split the string input.
-\begin{lstlisting}[language=java,label=lis:LexerStringSplit,caption=The string is being split and new lines are added to the string .,firstnumber=8]
+\begin{lstlisting}[language=Kotlin,label=lis:LexerStringSplit,caption=The string is being split and new lines are added to the string .,firstnumber=8]
 override fun getTokenSequence(): Sequence<PositionalToken> = buildSequence {
 	val currentString = StringBuilder()
 	inputContent.split(endOfLineRegex).forEachIndexed lineIterator@{ lineNumber, line ->
@@ -53,7 +53,7 @@ override fun getTokenSequence(): Sequence<PositionalToken> = buildSequence {
 \end{lstlisting}		
 It will then match the characters to either a type, a boolean value, a special character, an identifier or a number literal.
 If this is not possible, it can be assumed that the split string, meaning the current line, is done.
-\begin{lstlisting}[language=java,label=lis:LexerStringMatcher,caption=The split string is being matched to a token,firstnumber=19]
+\begin{lstlisting}[language=Kotlin,label=lis:LexerStringMatcher,caption=The split string is being matched to a token,firstnumber=19]
 
 when {
 	// special char

--- a/report/4.Solution/ParserImplementation.tex
+++ b/report/4.Solution/ParserImplementation.tex
@@ -51,7 +51,7 @@ The EBNF reveals that a declaration is:
 Based on this, the \textit{parseDeclaration} is implemented as seen in snippet \ref{lis:parseDeclaration}.
 Do note, the final parse declaration method is a little more complex due to type inference and type checking.
 
-\begin{lstlisting}[language=java,label=lis:parseDeclaration,caption=A simplified version of the parse declaration method from the parser.]
+\begin{lstlisting}[language=Kotlin,label=lis:parseDeclaration,caption=A simplified version of the parse declaration method from the parser.]
 private fun parseDeclaration(): TreeNode.Command.Declaration {
     val type = parseType()
     val identifierToken = accept<Token.Identifier>()
@@ -72,7 +72,7 @@ In snippet \ref{lis:parseCommand} a subset of the parse command method is shown.
 If the current token is a type, a declaration should be passed. 
 If the current token is an identifier, it is the next token that determines whether to parse an assignment or an expression.
 
-\begin{lstlisting}[language=java,label=lis:parseCommand,caption=A simplified version of the parse declaration method from the parser.]
+\begin{lstlisting}[language=Kotlin,label=lis:parseCommand,caption=A simplified version of the parse declaration method from the parser.]
 private fun parseCommand(): AstNode.Command {
     val command = when (current.token) {
 	    is Token.Type -> parseDeclaration()

--- a/report/4.Solution/SymbolTable.tex
+++ b/report/4.Solution/SymbolTable.tex
@@ -25,7 +25,7 @@ It is, however, not an major issue as it is not expected that the user of HCL wi
 \textbf{Implementation}\\
 The interface consists of five methods as seen in snippet \ref{lis:STInterface}.
 
-\begin{lstlisting}[language=java,label=lis:STInterface,caption=The interface which all symbol table implementations must implement.]
+\begin{lstlisting}[language=Kotlin,label=lis:STInterface,caption=The interface which all symbol table implementations must implement.]
 interface ISymbolTable{
 	fun openScope()
 	fun closeScope()
@@ -38,7 +38,7 @@ The interface, and implementations of it, are defined by opening and closing sco
 
 When opening a scope, a new scope is added to the stack, while the top scope is popped when running the $closeScope()$ method.
 
-\begin{lstlisting}[language=java,label=lis:STEnterSymbol,caption=A simplified version of the enterSymbol implementation.]
+\begin{lstlisting}[language=Kotlin,label=lis:STEnterSymbol,caption=A simplified version of the enterSymbol implementation.]
 override fun enterSymbol(name: String, type: AstNode.Type): EnterSymbolResult {
 	val entry = symbolTable.last[name]
 	return if (entry != null) {

--- a/report/preamb.tex
+++ b/report/preamb.tex
@@ -2,7 +2,7 @@
 
 \makeatletter
 %%%% PAKKER %%%%
-
+\usepackage[usenames,dvipsnames]{xcolor}
 % ¤¤ Oversaettelse og tegnsaetning ¤¤ %
 \usepackage[utf8]{inputenc}					% Input-indkodning af tegnsaet (UTF8)
 \usepackage[english]{babel}					% Dokumentets sprog
@@ -33,7 +33,7 @@
 \usepackage{graphicx} 						% Haandtering af eksterne billeder (JPG, PNG, PDF)
 \usepackage{multirow}                		% Fletning af raekker og kolonner (\multicolumn og \multirow)
 \usepackage{colortbl} 						% Farver i tabeller (fx \columncolor, \rowcolor og \cellcolor)
-\usepackage{xcolor}				            % Definer farver med \definecolor. Se mere: http://en.wikibooks.org/wiki/LaTeX/Colors
+%\usepackage{xcolor}				            % Definer farver med \definecolor. Se mere: http://en.wikibooks.org/wiki/LaTeX/Colors
 \usepackage{flafter}						% Soerger for at floats ikke optraeder i teksten foer deres reference
 \let\newfloat\relax 						% Justering mellem float-pakken og memoir
 \usepackage{float}							% Muliggoer eksakt placering af floats, f.eks. \begin{figure}[H]
@@ -56,7 +56,45 @@
 
 % ¤¤ Misc. ¤¤ %
 \usepackage{listings}						% Placer kildekode i dokumentet med \begin{lstlisting}...\end{lstlisting}
-                                            % Kode-style
+% Kode-style
+\lstdefinestyle{Kotlin}{language=kotlin, frame=lr, rulecolor=\color{blue!80!black}}
+\renewcommand{\lstlistingname}{Snippet}                                            
+\lstdefinelanguage{Kotlin}{
+	keywords={package, as, as?, typealias, this, super, val, var, fun, for, null, true, false, is, in, throw, return, break, continue, object, if, try, else, while, do, when, class, interface, enum, object, companion, override, public, private, get, set, import, abstract, vararg, expect, actual, where, suspend, data, internal, dynamic, final, by},
+	keywordstyle=\color{NavyBlue}\bfseries,
+	ndkeywords={@Deprecated, @JvmName, @JvmStatic, @JvmOverloads, @JvmField, @JvmSynthetic, Iterable, Int, Long, Integer, Short, Byte, Float, Double, String, Runnable, Array},
+	ndkeywordstyle=\color{BurntOrange}\bfseries,
+	emph={println, return@, forEach, map, mapNotNull, first, filter, firstOrNull, lazy, delegate},
+	emphstyle={\color{OrangeRed}},
+	identifierstyle=\color{black},
+	sensitive=true,
+	commentstyle=\color{gray}\ttfamily,
+	comment=[l]{//},
+	morecomment=[s]{/*}{*/},
+	stringstyle=\color{ForestGreen}\ttfamily,
+	morestring=[b]",
+	morestring=[s]{"""*}{*"""},
+}
+
+\lstdefinestyle{HCL}{language=hcl, frame, lr, rulecolor=\color{blue!80!black}}
+\renewcommand{\lstlistingname}{Snippet}
+\lstdefinelanguage{HCL}
+{
+	keywords={true, false, return, return}, 
+	keywordstyle=\color{ForestGreen}\bfseries,
+	ndkeywords={txt, num, bool, tuple, list, func, value},
+	ndkeywordstyle=\color{BurntOrange}\bfseries,
+	emph={map, filter, reduce, print, add, where, do, equals, thenElse}, %add all included functions here
+	emphstyle={\color{RoyalBlue}},
+	identifierstyle=\color{Maroon},
+	sensitive=true,
+	commentstyle=\color{Gray}\ttfamily,
+	comment=[l]{\#},
+	stringstyle=\color{black}\ttfamily,
+	morestring=[b]",	
+}
+                                       
+                                       
 \lstdefinestyle{CSharp}{language=[sharp]c, frame=lr, rulecolor=\color{blue!80!black}}
 
 \renewcommand{\lstlistingname}{Snippet}     % Listing navn


### PR DESCRIPTION
### Description
Added Kotlin and HCL latex listings
Colors may be a bit childish, so perhaps consider that.

### Changelog
- Added Kotlin listing and changed the appropriate existing listings
- Added HCL listing and changed the appropriate existing listings

### Issues solved 
add these with the respective key as HCLANG-1 (as an example)
 - HCLANG-79

### Issues opened as a result of this 
Add something here if new issues arise because of this. For instance if new features-requests or bugs arise from this PR. If this is not the case, then remove this section.

## FOR REVIEWER [Do not remove]
A small checklist of things to note when you are doing a review. Make sure these things apply before going into master.
 - Did the PR actually fix the issue
 - Comment anything that doesn't make sense or anything you want clarified. Many comments are always ok
 - Make sure this is ready for exams if this is going into master
 - It's always a good idea having another reviewer look at a PR as well, if it's major. get a buddy.

### Regarding filenames
- all .tex files use pascal case
- all other files [except in /code/] use snake case


### Regarding code [if applicable]
- Check [coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html)
- Are public methods documented? 
- Are there testcases for new features / methods?
- Have you tried running the source and tested things that cannot be test-cased?

### Regarding Report [if applicable]
- Does each line have a linechange in the sourcecode?
- Does sentences make sense?
- Did you do spellchecking?
- Citations?
