### PR TITLE
Hclang 82 - divide tests to multiple files

### DIFF
--- a/code/src/test/kotlin/parserTests/FunctionDeclarationTests.kt
+++ b/code/src/test/kotlin/parserTests/FunctionDeclarationTests.kt
@@ -7,7 +7,6 @@ import hclTestFramework.parser.*
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
-import parser.AstNode
 import parser.ParserWithoutBuiltins
 
 
@@ -92,38 +91,6 @@ class FunctionDeclarationTests {
             )
         )
     }
-/*
-    @Test
-    fun failsOnAssignmentInLambdaParameterDefinition(){
-        val lexer = DummyLexer(buildTokenSequence {
-                Type.List,
-                squareStart,
-                number,
-                squareEnd,
-                identifier("ret+2"),
-                `=`,
-                squareStart,
-                number(),
-                squareEnd,
-                newLine,
-                Type.List,
-                squareStart,
-                Type.List,
-                squareStart,
-                number,
-                squareEnd,
-                squareEnd,
-                Identifier,
-                `=`,
-                squareStart,
-                Identifier,
-                squareEnd,
-                newLine
-        ))
-        Assertions.assertThrows(InitializedFunctionParameterError::class.java,
-                { Parser(lexer).generateAbstractSyntaxTree() })
-
-    }*/
 
     @org.junit.jupiter.api.Test
     fun parsesWithImplicitFuncType() {
@@ -234,6 +201,20 @@ class FunctionDeclarationTests {
                 "myFunc" declaredAs func(none) withValue
                         body("myNum" declaredAs num, "myText" declaredAs txt).asExpression
             )
+        )
+    }
+
+    @Test
+    fun canParseVarAssignmentFunction() {
+        assertThat(
+                buildTokenSequence {
+                    `var`.identifier("myFunc").`=`.`(`.number.identifier("x").`)`.colon.bool.`{`.bool(true).blockEnd.newLine
+                },
+                matchesAstChildren(
+                        "myFunc" declaredAs func(bool, num) withValue (
+                                lambda() returning bool withArgument ("x" asType num) withBody ret(bool(true))
+                                )
+                )
         )
     }
 }

--- a/code/src/test/kotlin/parserTests/GenericsTests.kt
+++ b/code/src/test/kotlin/parserTests/GenericsTests.kt
@@ -7,11 +7,8 @@ import exceptions.UnexpectedTokenError
 import exceptions.UnexpectedTypeError
 import hclTestFramework.lexer.buildTokenSequence
 import hclTestFramework.parser.*
-import lexer.Token
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import parser.AstNode
-import parser.Parser
 import parser.ParserWithoutBuiltins
 
 class GenericsTests{

--- a/code/src/test/kotlin/parserTests/LambdaTests.kt
+++ b/code/src/test/kotlin/parserTests/LambdaTests.kt
@@ -6,7 +6,6 @@ import exceptions.UndeclaredError
 import exceptions.UnexpectedReturnTypeError
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 class LambdaTests {
     @Test

--- a/code/src/test/kotlin/parserTests/MiscellaneousTests.kt
+++ b/code/src/test/kotlin/parserTests/MiscellaneousTests.kt
@@ -1,114 +1,11 @@
 package parserTests
 
-import com.natpryce.hamkrest.assertion.assertThat
-import exceptions.ImplicitTypeNotAllowed
-import exceptions.UnexpectedTypeError
 import hclTestFramework.lexer.buildTokenSequence
-import hclTestFramework.parser.*
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import parser.ParserWithoutBuiltins
 
 class MiscellaneousTests {
-
-    @Test
-    fun canParseNumDeclaration() {
-        assertThat(
-            buildTokenSequence {
-                number.identifier("myId").`=`.number(5.0).newLine
-            },
-            matchesAstChildren("myId" declaredAs num withValue num(5))
-        )
-    }
-
-    @Test
-    fun failOnWrongType() {
-        val lexer = DummyLexer(buildTokenSequence {
-            bool.identifier("myId").`=`.number(5.0).newLine
-        })
-        Assertions.assertThrows(UnexpectedTypeError::class.java) { ParserWithoutBuiltins(lexer).generateAbstractSyntaxTree() }
-    }
-
-    @Test
-    fun canParseBool() {
-        assertThat(
-            buildTokenSequence {
-                bool.identifier("myBool").`=`.bool(true).newLine
-            },
-            matchesAstChildren("myBool" declaredAs bool withValue bool(true))
-        )
-    }
-
-    @Test
-    fun canParseNumAssignment() {
-        assertThat(
-            buildTokenSequence {
-                number.identifier("myId").newLine.identifier("myId").`=`.number(5.0).newLine
-            },
-            matchesAstChildren(
-                "myId" declaredAs num,
-                "myId" assignedTo num(5)
-            )
-        )
-    }
-
-    @Test
-    fun canParseVarAssignmentNumber() {
-        assertThat(
-            buildTokenSequence {
-                `var`.identifier("myId").`=`.number(5.0).newLine
-            },
-            matchesAstChildren("myId" declaredAs num withValue num(5))
-        )
-    }
-
-    @Test
-    fun canParseVarAssignmentList() {
-        assertThat(
-            buildTokenSequence {
-                `var`.identifier("myList").`=`.squareStart.number(5.0).`,`.number(7.0).squareEnd.newLine
-            },
-            matchesAstChildren("myList" declaredAs list(num) withValue list(num(5), num(7)))
-        )
-    }
-
-    @Test
-    fun canParseVarAssignmentFunction() {
-        assertThat(
-            buildTokenSequence {
-                `var`.identifier("myFunc").`=`.`(`.number.identifier("x").`)`.colon.bool.`{`.bool(true).blockEnd.newLine
-            },
-            matchesAstChildren(
-                "myFunc" declaredAs func(bool, num) withValue (
-                    lambda() returning bool withArgument ("x" asType num) withBody ret(bool(true))
-                )
-            )
-        )
-    }
-
-
-    @Test
-    fun canParseNumAssignmentWithIdentifier() {
-        assertThat(
-            buildTokenSequence {
-                number.identifier("myNumber").`=`.number(5.0).newLine.number.identifier("myId").`=`.identifier("myNumber").newLine
-            },
-            matchesAstChildren(
-                "myNumber" declaredAs num withValue num(5),
-                "myId" declaredAs num withValue "myNumber".asIdentifier
-            )
-        )
-    }
-
-    @org.junit.jupiter.api.Test
-    fun failsOnImplicitFuncAsParameter() {
-        val lexer = DummyLexer(buildTokenSequence {
-            list.squareStart.func.squareEnd.identifier("myFunc").newLine
-        })
-        assertThrows(ImplicitTypeNotAllowed::class.java) { ParserWithoutBuiltins(lexer).generateAbstractSyntaxTree() }
-    }
-
     @Test
     fun failsOnLineStartsWithEquals() {
         val lexer = DummyLexer(buildTokenSequence {

--- a/code/src/test/kotlin/parserTests/PrimitiveTypeTests.kt
+++ b/code/src/test/kotlin/parserTests/PrimitiveTypeTests.kt
@@ -1,0 +1,94 @@
+package parserTests
+
+import com.natpryce.hamkrest.assertion.assertThat
+import exceptions.UnexpectedTypeError
+import hclTestFramework.lexer.buildTokenSequence
+import hclTestFramework.parser.*
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import parser.ParserWithoutBuiltins
+
+class PrimitiveTypeTests {
+    @Test
+    fun canParseNumDeclaration() {
+        assertThat(
+                buildTokenSequence {
+                    number.identifier("myId").`=`.number(5.0).newLine
+                },
+                matchesAstChildren("myId" declaredAs num withValue num(5))
+        )
+    }
+    @Test
+    fun canParseTxtDeclaration(){
+        assertThat(
+                buildTokenSequence {
+                    text.identifier("myText").`=`.text("someText").newLine
+                },
+                matchesAstChildren("myText" declaredAs txt withValue txt("someText"))
+        )
+    }
+    @Test
+    fun canParseBoolDeclaration() {
+        assertThat(
+                buildTokenSequence {
+                    bool.identifier("myBool").`=`.bool(true).newLine
+                },
+                matchesAstChildren("myBool" declaredAs bool withValue bool(true))
+        )
+    }
+    @Test
+    fun canParseNumAssignment() {
+        assertThat(
+                buildTokenSequence {
+                    number.identifier("myId").newLine.identifier("myId").`=`.number(5.0).newLine
+                },
+                matchesAstChildren(
+                        "myId" declaredAs num,
+                        "myId" assignedTo num(5)
+                )
+        )
+    }
+    @Test
+    fun canParseTxtAssignment() {
+        assertThat(
+                buildTokenSequence {
+                    text.identifier("myText").newLine.identifier("myText").`=`.text("someText").newLine
+                },
+                matchesAstChildren(
+                        "myText" declaredAs txt,
+                        "myText" assignedTo txt("someText")
+                )
+        )
+    }
+    @Test
+    fun canParseNumAssignmentWithIdentifier() {
+        assertThat(
+                buildTokenSequence {
+                    number.identifier("myNumber").`=`.number(5.0).newLine.number.identifier("myId")
+                            .`=`.identifier("myNumber").newLine
+                },
+                matchesAstChildren(
+                        "myNumber" declaredAs num withValue num(5),
+                        "myId" declaredAs num withValue "myNumber".asIdentifier
+                )
+        )
+    }
+
+    @Test
+    fun canParseVarAssignmentNumber() {
+        assertThat(
+                buildTokenSequence {
+                    `var`.identifier("myId").`=`.number(5.0).newLine
+                },
+                matchesAstChildren("myId" declaredAs num withValue num(5))
+        )
+    }
+    @Test
+    fun failOnWrongType() {
+        val lexer = DummyLexer(buildTokenSequence {
+            bool.identifier("myId").`=`.number(5.0).newLine
+        })
+        Assertions.assertThrows(UnexpectedTypeError::class.java)
+            { ParserWithoutBuiltins(lexer).generateAbstractSyntaxTree() }
+    }
+}

--- a/code/src/test/kotlin/parserTests/TupleTests.kt
+++ b/code/src/test/kotlin/parserTests/TupleTests.kt
@@ -10,7 +10,6 @@ import parser.ParserWithoutBuiltins
 
 class TupleTests
 {
-
     @org.junit.jupiter.api.Test
     fun parseTupleTypeWithoutAssignment() {
         assertThat(
@@ -25,9 +24,11 @@ class TupleTests
     fun parseTupleWithAssignment() {
         assertThat(
             buildTokenSequence {
-                tuple.squareStart.number.`,`.text.squareEnd.identifier("myTuple").`=`.`(`.number(5.0).`,`.text("someText").`)`.newLine
+                tuple.squareStart.number.`,`.text.squareEnd.identifier("myTuple").`=`.`(`.number(5.0)
+                        .`,`.text("someText").`)`.newLine
             },
-            matchesAstChildren("myTuple" declaredAs tpl(num, txt) withValue tpl(num(5), txt("someText")))
+            matchesAstChildren("myTuple" declaredAs tpl(num, txt) withValue tpl(num(5),
+                               txt("someText")))
         )
     }
 
@@ -44,17 +45,21 @@ class TupleTests
     @org.junit.jupiter.api.Test
     fun failsOnNotEnoughSeparators() {
         val lexer = DummyLexer(buildTokenSequence {
-            tuple.squareStart.number.`,`.text.squareEnd.identifier("myTuple").`=`.`(`.number(5.0).text("someText").`)`.newLine
+            tuple.squareStart.number.`,`.text.squareEnd.identifier("myTuple").`=`.`(`.number(5.0)
+                    .text("someText").`)`.newLine
         })
-        Assertions.assertThrows(WrongTokenTypeError::class.java) { ParserWithoutBuiltins(lexer).generateAbstractSyntaxTree() }
+        Assertions.assertThrows(WrongTokenTypeError::class.java)
+            { ParserWithoutBuiltins(lexer).generateAbstractSyntaxTree() }
     }
 
     @org.junit.jupiter.api.Test
     fun failsOnTupleAssignmentFailsOnTooManySeparators() {
         val lexer = DummyLexer(buildTokenSequence {
-            tuple.squareStart.number.`,`.text.squareEnd.identifier("myTuple").`=`.`(`.number(5.0).`,`.`,`.text("someText").`)`.newLine
+            tuple.squareStart.number.`,`.text.squareEnd.identifier("myTuple").`=`.`(`.number(5.0)
+                    .`,`.`,`.text("someText").`)`.newLine
         })
-        Assertions.assertThrows(UnexpectedTokenError::class.java) { ParserWithoutBuiltins(lexer).generateAbstractSyntaxTree() }
+        Assertions.assertThrows(UnexpectedTokenError::class.java)
+            { ParserWithoutBuiltins(lexer).generateAbstractSyntaxTree() }
     }
 
 }


### PR DESCRIPTION
Divided tests into multiple files (one file for each type of tests (list, functionCAll, primitive-types osv..))

### Changelog
 - spread out tests
   - new file for primitive files
   - couple tests for txt-declarations/assignments

### Issues solved 
 - HCLANG-82


## FOR REVIEWER [Do not remove]
A small checklist of things to note when you are doing a review. Make sure these things apply before going into master.
 - Did the PR actually fix the issue
 - Comment anything that doesn't make sense or anything you want clarified. Many comments are always ok
 - Make sure this is ready for exams if this is going into master
 - It's always a good idea having another reviewer look at a PR as well, if it's major. get a buddy.

### Regarding filenames
- all .tex files use pascal case
- all other files [except in /code/] use snake case


### Regarding code [if applicable]
- Check [coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html)
- Are public methods documented? 
- Are there testcases for new features / methods?
- Have you tried running the source and tested things that cannot be test-cased?

### Regarding Report [if applicable]
- Does each line have a linechange in the sourcecode?
- Does sentences make sense?
- Did you do spellchecking?
- Citations?
