### PR TITLE
Fixed while return type and ftoa not including <cstdio>

### DIFF
--- a/code/src/main/kotlin/builtins/HclBuiltinFunctions.kt
+++ b/code/src/main/kotlin/builtins/HclBuiltinFunctions.kt
@@ -294,7 +294,7 @@ private fun buildWhileFunction() = buildFunction(
         Parameter("body", Type.Func(listOf(), Type.None)),
         Parameter("condition", Type.Func(listOf(), Type.Bool))
     ),
-    returnType = Type.Bool,
+    returnType = Type.None,
     body = "while (condition()) body();"
 )
 

--- a/code/src/main/resources/ftoa.h
+++ b/code/src/main/resources/ftoa.h
@@ -2,6 +2,7 @@
 #define FTOA_H
 
 #include <cstdlib>
+#include <cstdio>
 #define MAX_STR_LEN 16
 
 /*


### PR DESCRIPTION
### Description
While function used to have wrong return type
Ftoa didn't include \<cstdio\> library, which caused errors on some compilers

### Changelog
 - Changed "while" return type from Bool to None
 - Made ftoa.h include \<cstdio\> library, which contains sprintf()

### Issues solved 
This is just a quick fix, no issue should be needed

## FOR REVIEWER [Do not remove]
A small checklist of things to note when you are doing a review. Make sure these things apply before going into master.
 - Did the PR actually fix the issue
 - Comment anything that doesn't make sense or anything you want clarified. Many comments are always ok
 - Make sure this is ready for exams if this is going into master
 - It's always a good idea having another reviewer look at a PR as well, if it's major. get a buddy.

### Regarding filenames
- all .tex files use pascal case
- all other files [except in /code/] use snake case


### Regarding code [if applicable]
- Check [coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html)
- Are public methods documented? 
- Are there testcases for new features / methods?
- Have you tried running the source and tested things that cannot be test-cased?

### Regarding Report [if applicable]
- Does each line have a linechange in the sourcecode?
- Does sentences make sense?
- Did you do spellchecking?
- Citations?
