### PR TITLE
Tried to fix unprecise logger

### DIFF
--- a/code/src/main/kotlin/parser/ParserErrors.kt
+++ b/code/src/main/kotlin/parser/ParserErrors.kt
@@ -4,61 +4,72 @@ import exceptions.* // ktlint-disable no-wildcard-imports
 import lexer.Token
 
 fun Parser.unexpectedTypeError(expectedType: String, actualType: String): Nothing {
-    throw UnexpectedTypeError(current.lineNumber, current.lineIndex,
-            lexer.inputLine(current.lineNumber, current.fileName), expectedType, actualType)
+    throw UnexpectedTypeError(setLineNumber(), setLineIndex(1),
+            setInputLine(), expectedType, actualType)
 }
 
 fun Parser.unexpectedReturnTypeError(expectedType: String, actualType: String): Nothing {
-    throw UnexpectedReturnTypeError(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber,
-            current.fileName), expectedType, actualType)
+    throw UnexpectedReturnTypeError(setLineNumber(1), setLineIndex(2),
+            setInputLine(2), expectedType, actualType)
 }
 
 fun Parser.unexpectedTokenError(token: Token): Nothing {
-    throw UnexpectedTokenError(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber,
-            current.fileName), token)
+    throw UnexpectedTokenError(setLineNumber(), setLineIndex(1),
+            setInputLine(), token)
 }
 
 fun Parser.lackingParanthesis(): Nothing {
-    throw LackingParanthesisError(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber,
-            current.fileName), current.token)
+    throw LackingParanthesisError(setLineNumber(), setLineIndex(),
+            setInputLine(), current.token)
 }
 
 fun Parser.undeclaredError(str: String): Nothing {
-    throw UndeclaredError(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber, current.fileName),
+    throw UndeclaredError(setLineNumber(), setLineIndex(1), setInputLine(),
             str)
 }
 
 fun Parser.implicitTypeNotAllowedError(): Nothing {
-    throw ImplicitTypeNotAllowed(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber,
-            current.fileName))
+    throw ImplicitTypeNotAllowed(setLineNumber(), setLineIndex(1),
+            setInputLine())
 }
 
 fun Parser.wrongTokenTypeError(name: String, token: Token): Nothing {
-    throw WrongTokenTypeError(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber,
-            current.fileName), name, token)
+    throw WrongTokenTypeError(setLineNumber(), setLineIndex(1),
+            setInputLine(), name, token)
 }
 
 fun Parser.initializedFunctionParameterError(): Nothing {
-    throw InitializedFunctionParameterError(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber,
-            current.fileName))
+    throw InitializedFunctionParameterError(setLineNumber(), setLineIndex(1),
+            setInputLine())
 }
 
 fun Parser.genericPassedFunctionException(): Nothing {
-    throw GenericPassedFunctionException(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber,
-            current.fileName))
+    throw GenericPassedFunctionException(setLineNumber(), setLineIndex(1),
+            setInputLine())
 }
 
 fun Parser.alreadyDeclaredException(): Nothing {
-    throw AlreadyDeclaredException(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber,
-            current.fileName))
+    throw AlreadyDeclaredException(setLineNumber(), setLineIndex(3),
+            setInputLine())
 }
 
 fun Parser.overloadWithDifferentAmountOfArgumentsException(): Nothing {
-    throw OverloadWithDifferentAmountOfArgumentsException(current.lineNumber, current.lineIndex,
-            lexer.inputLine(current.lineNumber, current.fileName))
+    throw OverloadWithDifferentAmountOfArgumentsException(setLineNumber(), setLineIndex(6),
+            setInputLine())
 }
 
 fun Parser.error(msg: String, helpText: String = ""): Nothing {
-    throw GenericParserException(current.lineNumber, current.lineIndex, lexer.inputLine(current.lineNumber,
-            current.fileName), msg, helpText)
+    throw GenericParserException(setLineNumber(), setLineIndex(0),
+            setInputLine(), msg, helpText)
+}
+
+fun Parser.setLineNumber(shifts: Int = 0): Int{
+    return lookBehind(shifts).lineNumber
+}
+fun Parser.setLineIndex(shifts: Int = 0): Int{
+    return lookBehind(shifts).lineIndex
+}
+fun Parser.setInputLine(shifts: Int = 0): String{
+    return lexer.inputLine(lookBehind(shifts).lineNumber,
+           lookBehind(shifts).fileName)
 }


### PR DESCRIPTION
The logger has often had trouple pointing to the correct token when errors occur.
the problem seems to be that it oftens points to the next token in the line.
I have tried to fix most cases simply using the lookBehind() method.
Outliars are still found.

### Changelog
 - Better logging precision

### Issues solved 
 - HCLANG-144

### Issues opened as a result of this 
Add something here if new issues arise because of this. For instance if new features-requests or bugs arise from this PR. If this is not the case, then remove this section.

## FOR REVIEWER [Do not remove]
A small checklist of things to note when you are doing a review. Make sure these things apply before going into master.
 - Did the PR actually fix the issue
 - Comment anything that doesn't make sense or anything you want clarified. Many comments are always ok
 - Make sure this is ready for exams if this is going into master
 - It's always a good idea having another reviewer look at a PR as well, if it's major. get a buddy.

### Regarding filenames
- all .tex files use pascal case
- all other files [except in /code/] use snake case


### Regarding code [if applicable]
- Check [coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html)
- Are public methods documented? 
- Are there testcases for new features / methods?
- Have you tried running the source and tested things that cannot be test-cased?

### Regarding Report [if applicable]
- Does each line have a linechange in the sourcecode?
- Does sentences make sense?
- Did you do spellchecking?
- Citations?
